### PR TITLE
Add noopener along with _target blank for security

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Jekyll Target Blank Logo](assets/logo.png "Jekyll Target Blank")
 
-Automatically adds a `target="_blank"` attribute to all __external__ links in Jekyll Content. [Read more..](https://keith-mifsud.me/projects/jekyll-target-blank)
+Automatically adds a `target="_blank" rel="noopener noreferrer"` attribute to all __external__ links in Jekyll Content. [Read more..](https://keith-mifsud.me/projects/jekyll-target-blank)
 
 [![Gem Version](https://badge.fury.io/rb/jekyll-target-blank.svg)](https://badge.fury.io/rb/jekyll-target-blank)
 [![Build Status](https://travis-ci.org/keithmifsud/jekyll-target-blank.svg?branch=master)](https://travis-ci.org/keithmifsud/jekyll-target-blank)
@@ -48,7 +48,7 @@ The following html anchor tag:
 will be replaced with:
 
 ```html
-<a href="https://google.com" target="_blank">Google</a>
+<a href="https://google.com" target="_blank" rel="noopener noreferrer">Google</a>
 ```
 
 ..unless your website's URL is google.com 😉
@@ -62,14 +62,14 @@ will be replaced with:
 will be generated as:
 
 ```html
-<a href="https://google.com" target="_blank">Google</a>
+<a href="https://google.com" target="_blank" rel="noopener noreferrer">Google</a>
 ```
 
 ## Support
 
 Simply [create an issue](https://github.com/keithmifsud/jekyll-target-blank/issues/new) and I will respond as soon as possible.
 
- 
+
 ## Contributing
 
 1. [Fork it](https://github.com/keithmifsud/jekyll-target-blank/fork)

--- a/lib/jekyll-target-blank.rb
+++ b/lib/jekyll-target-blank.rb
@@ -11,7 +11,7 @@ module Jekyll
 
     class << self
       # Public: Processes the content and updated the external links
-      # by adding the target="_blank" attribute.
+      # by adding target="_blank" and rel="noopener noreferrer" attributes.
       #
       # content - the document or page to be processes.
       def process(content)
@@ -58,6 +58,7 @@ module Jekyll
         anchors.each do |item|
           if not_mailto_link?(item["href"]) && external?(item["href"])
             item["target"] = "_blank"
+            item["rel"] = "noopener noreferrer"
           end
         end
         content.to_html

--- a/spec/jekyll-target_spec.rb
+++ b/spec/jekyll-target_spec.rb
@@ -53,17 +53,17 @@ RSpec.describe(Jekyll::TargetBlank) do
   end
 
   it "should add target attribute to external markdown link" do
-    expect(post_with_external_markdown_link.output).to include(para('Link to <a href="https://google.com" target="_blank">Google</a>.'))
+    expect(post_with_external_markdown_link.output).to include(para('Link to <a href="https://google.com" target="_blank" rel="noopener noreferrer">Google</a>.'))
   end
 
   it "should add target attribute to multiple external markdown links" do
-    expect(post_with_multiple_external_markdown_links.output).to include('<p>This post contains three links. The first link is to <a href="https://google.com" target="_blank">Google</a>, the second link is, well, to <a href="https://keithmifsud.github.io" target="_blank">my website</a> and since <a href="https://github.com" target="_blank">GitHub</a> is so awesome, why not link to them too?</p>')
+    expect(post_with_multiple_external_markdown_links.output).to include('<p>This post contains three links. The first link is to <a href="https://google.com" target="_blank" rel="noopener noreferrer">Google</a>, the second link is, well, to <a href="https://keithmifsud.github.io" target="_blank" rel="noopener noreferrer">my website</a> and since <a href="https://github.com" target="_blank" rel="noopener noreferrer">GitHub</a> is so awesome, why not link to them too?</p>')
   end
 
   it "should not add target attribute to relative markdown link" do
     expect(post_with_relative_markdown_link.output).to include(para('Link to <a href="/contact">contact page</a>.'))
 
-    expect(post_with_relative_markdown_link.output).to_not include(para('Link to <a href="/contact" target="_blank">contact page</a>'))
+    expect(post_with_relative_markdown_link.output).to_not include(para('Link to <a href="/contact" target="_blank" rel="noopener noreferrer">contact page</a>'))
   end
 
   it "should not add target attribute to absolute internal link" do
@@ -72,7 +72,7 @@ RSpec.describe(Jekyll::TargetBlank) do
   end
 
   it "should correctly handle existing html anchor tag" do
-    expect(post_with_html_anchor_tag.output).to include('<p>This is an <a href="https://google.com" target="_blank">anchor tag</a>.</p>
+    expect(post_with_html_anchor_tag.output).to include('<p>This is an <a href="https://google.com" target="_blank" rel="noopener noreferrer">anchor tag</a>.</p>
 ')
   end
 
@@ -82,12 +82,12 @@ RSpec.describe(Jekyll::TargetBlank) do
   end
 
   it "should process external links in collections" do
-    expect(document_with_a_processable_link.output).to include('<p>This is a valid <a href="https://google.com" target="_blank">link</a>.</p>
+    expect(document_with_a_processable_link.output).to include('<p>This is a valid <a href="https://google.com" target="_blank" rel="noopener noreferrer">link</a>.</p>
 ')
   end
 
   it "should process external links in pages" do
-    expect(site.pages.first.output).to include('<p>This is a valid <a href="https://google.com" target="_blank">link</a>.</p>')
+    expect(site.pages.first.output).to include('<p>This is a valid <a href="https://google.com" target="_blank" rel="noopener noreferrer">link</a>.</p>')
   end
 
   it "should not process links in non html files" do
@@ -99,7 +99,7 @@ RSpec.describe(Jekyll::TargetBlank) do
 
     expect(post_with_code_block.output).not_to include("<span class=\"s1\"><a href=\"https://google.com\" target=\"_blank\">https://google.com</a></span>")
 
-    expect(post_with_code_block.output).to include('<p>Valid <a href="https://google.com" target="_blank">link</a></p>
+    expect(post_with_code_block.output).to include('<p>Valid <a href="https://google.com" target="_blank" rel="noopener noreferrer">link</a></p>
 ')
   end
 
@@ -144,7 +144,7 @@ RSpec.describe(Jekyll::TargetBlank) do
 </head>
 <body class="wrap">
     <div>Layout content started.</div>
-<p>Link to <a href="https://google.com" target="_blank">Google</a>.</p>
+<p>Link to <a href="https://google.com" target="_blank" rel="noopener noreferrer">Google</a>.</p>
 
     <div>Layout content ended.</div>
 </body>


### PR DESCRIPTION
This is for security reasons. Without it, if a user clicks an external link the target page will have full access to the `window` object!

To fix this we add `rel="noopener noreferrer"` along with `_target="blank"`. `noreferrer` is for older browsers that does not support `noopener`.

For more information see https://mathiasbynens.github.io/rel-noopener/