### PR TITLE
Fix layout breaking

### DIFF
--- a/lib/jekyll-target-blank.rb
+++ b/lib/jekyll-target-blank.rb
@@ -7,7 +7,7 @@ require "uri"
 module Jekyll
   class TargetBlank
     BODY_START_TAG         = "<body"
-    OPENING_BODY_TAG_REGEX = %r!<body(.*)>\s*!
+    OPENING_BODY_TAG_REGEX = %r!<body([^<>]*)>\s*!
 
     class << self
       # Public: Processes the content and updated the external links


### PR DESCRIPTION
The regex `<body(.*)>\s*` matches `<body><header class="site-header" role="banner">` so that `</header>` will miss.
Modify the regex to `<body([^<>]*)>\s*` to fix this bug.