### PR TITLE
Please relax the Jekyll dependency to allow v4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ rvm:
 - 2.3
 before_install:
 - gem update --system
-- gem install bundler
+- gem install bundler -v 1.6
 script: scripts/cibuild
 sudo: false
 cache: bundler

--- a/jekyll-target-blank.gemspec
+++ b/jekyll-target-blank.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.required_ruby_version = ">= 2.3.0"
 
-  spec.add_dependency "jekyll", "~> 3.0"
+  spec.add_runtime_dependency "jekyll", ">= 3.6", "< 5.0"
   spec.add_dependency "nokogiri", "~> 1.8.2"
 
   spec.add_development_dependency "bundler", "~> 1.6"


### PR DESCRIPTION
Just replace spec.add_dependency "jekyll", "~> 3.0" to spec.add_runtime_dependency "jekyll", ">= 3.6", "< 5.0" for allow use of Jekyll v4.0