### PR TITLE
Corrected wrong example

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ or even more than one extra:
 
 ```yaml
 target-blank:
-    rel: nofollow
+    rel: nofollow canonical
 ```
 
 __Note:__


### PR DESCRIPTION
The second example about adding custom `rel`s was identical to the former, while another attribute should have been added.