### PR TITLE
Fix quality checks

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,12 +1,11 @@
-inherit_gem:
-  jekyll: .rubocop.yml
+
 
 AllCops:
   TargetRubyVersion: 2.6
   Exclude:
     - vendor/**/*
 
-Metrics/LineLength:
+Layout/LineLength:
   Exclude:
     - spec/**/*
     - jekyll-target-blank.gemspec

--- a/jekyll-target-blank.gemspec
+++ b/jekyll-target-blank.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rake', '~> 12.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
-  spec.add_development_dependency 'rubocop', '>= 0.68.0', '<= 0.72.0'
-  spec.add_development_dependency "rubocop-jekyll", "~> 0.10.0"
+  spec.add_development_dependency 'rubocop', '~> 1'
+  spec.add_development_dependency "rubocop-jekyll", "~> 0.12.0"
 
 end


### PR DESCRIPTION
- Update Rubocop to a version > 1
- Also updates rubocop-jekyll to 0.12.0
- Don't inherit .rubocop.yml from jekyll (.rubocop_todo.yml is not
  installed with a Gem, so that file is always missing)
- s/Metrics/Layout (https://github.com/keithmifsud/jekyll-target-blank/pull/57#issuecomment-1065227161)

This would resolve the CI check issues in #57, #52, and #46