### PR TITLE
handle URI::InvalidURIError by not processing the link

### DIFF
--- a/lib/jekyll-target-blank.rb
+++ b/lib/jekyll-target-blank.rb
@@ -192,8 +192,13 @@ module Jekyll
       #
       # link - a url.
       def external?(link)
-        if link&.match?(URI.regexp(%w(http https)))
-          URI.parse(link).host != URI.parse(@site_url).host
+        begin
+          if link&.match?(URI.regexp(%w(http https)))
+            URI.parse(link).host != URI.parse(@site_url).host
+          end
+        rescue URI::InvalidURIError
+           # don't do anything if you can't parse the link
+          return false
         end
       end
 

--- a/lib/jekyll-target-blank/version.rb
+++ b/lib/jekyll-target-blank/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module JekyllTargetBlank
-  VERSION = "2.0.0"
+  VERSION = "2.0.1"
 end

--- a/spec/fixtures/unit/_posts/2022-04-19-post-with-bookmarklet-link.html
+++ b/spec/fixtures/unit/_posts/2022-04-19-post-with-bookmarklet-link.html
@@ -1,0 +1,13 @@
+---
+layout: default
+title: Post with external markdown link containing query params
+---
+
+<p>
+  This is a dummy link containing a bookmarklet.
+</p>
+<p>Drag this link to your bookmarks, to copy webpage URL: <a href="javascript:(function() {
+  function copyToClipboard(text) {
+    if (window.clipboardData && window.clipboardData.setData) { /*IE specific code path to prevent textarea being shown while dialog is visible.*/ return clipboardData.setData('Text', text); } else if (document.queryCommandSupported && document.queryCommandSupported('copy')) { var textarea = document.createElement('textarea'); textarea.textContent = text; textarea.style.position = 'fixed'; /* Prevent scrolling to bottom of page in MS Edge.*/ document.body.appendChild(textarea); textarea.select(); try { return document.execCommand('copy'); /* Security exception may be thrown by some browsers.*/ } catch (ex) { console.warn('Copy to clipboard failed.', ex); return false; } finally { document.body.removeChild(textarea); } } } var markdown = document.title + ':' + '\r\n' + window.location.href; copyToClipboard(markdown);
+  })();"
+>Copy URL</a></p>

--- a/spec/fixtures/unit/_posts/2022-04-19-post-with-external-markdown-link-containing-query-params.md
+++ b/spec/fixtures/unit/_posts/2022-04-19-post-with-external-markdown-link-containing-query-params.md
@@ -1,0 +1,6 @@
+---
+layout: default
+title: Post with external markdown link containing query params
+---
+
+This is [a more complex link]((http://webcache.googleusercontent.com/search?q=cache:PvXcOA1WkQAJ:www.connexxa.it/%3Fa2_content_id%3D58%26catPadre%3D58%26section%3Dpagine%26a2_language%3Dit+&cd=1&hl=it&ct=clnk&gl=it)) with many query params.


### PR DESCRIPTION
Do not throw exception for unparsable URLs with particular query params, javascript bookmarklet, etc.
Added two file for testing purpose. No need to check for output in spec files, because if an exception is thrown tests will fail anyway.