### PR TITLE
Fixes #54: do not overwrite custom attributes

### DIFF
--- a/lib/jekyll-target-blank.rb
+++ b/lib/jekyll-target-blank.rb
@@ -153,7 +153,7 @@ module Jekyll
       #
       # link = Nokogiri node.
       def add_rel_attributes(link)
-        rel = ""
+        rel = link["rel"] || ""
         rel = add_noopener_to_rel(rel)
 
         if @should_add_noreferrrer

--- a/lib/jekyll-target-blank/version.rb
+++ b/lib/jekyll-target-blank/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module JekyllTargetBlank
-  VERSION = "2.0.1"
+  VERSION = "2.0.2"
 end


### PR DESCRIPTION
Keeps the existing `rel` attributes if they exist. Fixes #54 